### PR TITLE
Fix deprecated setting properties on Sanic version 21.12+

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,5 +1,5 @@
-sanic==18.12.0
-sanic-base-extension==0.1.1
+sanic==22.9
+sanic-base-extension @ git+https://github.com/karnzx/sanic-base-extension.git@f8707e1e18289e0da6a2cdcd900953003eb85510
 Marshmallow==2.18.1
 
 ipython==7.3.0

--- a/sanic_mongodb_ext/__init__.py
+++ b/sanic_mongodb_ext/__init__.py
@@ -17,17 +17,17 @@ class MongoDbExtension(BaseExtension):
 
         lazy_instance = app.config.get('LAZY_UMONGO', None)
         if lazy_instance is not None:
-            setattr(app, self.lazy_app_attribute, lazy_instance)
+            setattr(app.ctx, self.lazy_app_attribute, lazy_instance)
 
         @app.listener('before_server_start')
         async def mongodb_configure(app_inner, _loop):
             client_options = app_inner.config.get('MONGODB_CONNECT_OPTIONS', {})
             client = AsyncIOMotorClient(app_inner.config['MONGODB_URI'], **client_options)
-            setattr(app_inner, self.app_attribute, client)
+            setattr(app_inner.ctx, self.app_attribute, client)
 
-            if not hasattr(app, 'extensions'):
-                setattr(app, 'extensions', {})
-            app.extensions[self.extension_name] = client
+            if not hasattr(app.ctx, 'extensions'):
+                setattr(app.ctx, 'extensions', {})
+            app.ctx.extensions[self.extension_name] = client
 
             database = app_inner.config.get('MONGODB_DATABASE', None)
             if lazy_instance and database:
@@ -36,7 +36,7 @@ class MongoDbExtension(BaseExtension):
 
         @app.listener('after_server_stop')
         async def mongodb_free_resources(app_inner, _loop):
-            client = getattr(app_inner, self.app_attribute, None)
+            client = getattr(app_inner.ctx, self.app_attribute, None)
 
             if client:
                 client.close()


### PR DESCRIPTION
see https://sanic.dev/en/guide/release-notes/v21.12.html#strict-application-and-blueprint-properties
error image
![v21 12](https://user-images.githubusercontent.com/26167071/206447321-8f838d48-0683-45a1-bc50-00a69cd29670.png)

try with sanic version 21.12+ (22.9)
and edit sanic-base-extension on https://github.com/karnzx/sanic-base-extension/tree/fix/deprecated-setting-properties

usage change from `@app.ctx.lazy_umongo.register` instead of `@app.lazy_umongo.register`